### PR TITLE
refactor(api): simplify getResources method and update API endpoint `/api/search/resources`

### DIFF
--- a/services/api.ts
+++ b/services/api.ts
@@ -1,8 +1,3 @@
-
-import Logger from '@/utils/Logger';
-
-const logger = Logger.withTag('API');
-
 // region: --- Interface Definitions ---
 export interface DoubanItem {
   title: string;
@@ -213,43 +208,9 @@ export class API {
   }
 
   async getResources(signal?: AbortSignal): Promise<ApiSite[]> {
-    const url = `/api/admin/config`;
+    const url = `/api/search/resources`;
     const response = await this._fetch(url, { signal });
-    const config = await response.json();
-    
-    // 添加安全检查
-    if (!config || !config.Config.SourceConfig) {
-      logger.warn('API response missing SourceConfig:', config);
-      return [];
-    }
-    
-    // 确保 SourceConfig 是数组
-    if (!Array.isArray(config.Config.SourceConfig)) {
-      logger.warn('SourceConfig is not an array:', config.Config.SourceConfig);
-      return [];
-    }
-    
-    // 过滤并验证每个站点配置，同时进行去重
-    const seenKeys = new Set<string>();
-    const uniqueSites: ApiSite[] = [];
-    
-    config.Config.SourceConfig
-      .filter((site: any) => site && !site.disabled)
-      .forEach((site: any) => {
-        const key = site.key || '';
-        // 基于 key 字段去重
-        if (key && !seenKeys.has(key)) {
-          seenKeys.add(key);
-          uniqueSites.push({
-            key: key,
-            api: site.api || '',
-            name: site.name || '',
-            detail: site.detail
-          });
-        }
-      });
-    
-    return uniqueSites;
+    return response.json();
   }
 
   async getVideoDetail(source: string, id: string): Promise<VideoDetail> {


### PR DESCRIPTION
getResources 用回 `/api/search/resources`，避免`/api/admin/config`管理员权限问题。

无法获取自定义源是MoonTV的bug，新版本的（2.x以上）应该经解决了这个问题，`/api/search/resources`可以获取自定义的了。
所以这里我改回用这个api，MootTV的问题让MooTV解决吧